### PR TITLE
action id für das body tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,13 @@
 linuxmuster-schulkonsole (0.10.1-1) unstable; urgency=low
 
+    * Branch fuer neues template /fs
+    * Doppeltes menu div in login.shtml entfernt
+    * Template.pm angepasst, so dass das body tag die id der action erhält
+
+ -- Frank Schiebel <frank@linuxmuster.net>  Tue, 25 Sep 2012 16:43:00 +0200
+
+linuxmuster-schulkonsole (0.10.1-1) unstable; urgency=low
+
   * tschmitt:
     * Added dependency to libproc-processtable-perl to control (needed
       for precise).

--- a/lib/Schulkonsole/Template.pm
+++ b/lib/Schulkonsole/Template.pm
@@ -285,7 +285,7 @@ sub print_page {
 		marked_sections => 1,
 		attr_encoded => 1,
 	);
-	$p->report_tags('div', 'label', 'form', 'input', 'textarea', 'select',
+	$p->report_tags('body', 'div', 'label', 'form', 'input', 'textarea', 'select',
 	                'option', 'optgroup',
 	                'th', 'title', 'meta', 'html', 'span', 'a', 'gettext');
 
@@ -380,7 +380,6 @@ sub start_tag_handler {
 	my $action = shift;
 	my $tokenpos = shift;
 
-
 	if ($_in_gettext) {
 		$_skip_buffer .= $skipped_text . $text;
 	} else {
@@ -388,6 +387,8 @@ sub start_tag_handler {
 
 		if ($tagname eq 'gettext') {
 			$_in_gettext = 1;
+        } elsif ($tagname eq 'body') {
+            print_content("<body id=\"$action\">");
 		} elsif ($tagname eq 'form') {
 			my $anchor = $1 if $$attr_ref{action} =~ s/(#[^#]*)//;
 			if (not $$attr_ref{action}) {

--- a/shtml/login.shtml
+++ b/shtml/login.shtml
@@ -10,7 +10,6 @@
 
 <!--#include file="header.shtml.inc" -->
 
-<div id="menu"> </div>
 <div id="special"> </div>
 
 <div id="submenu">


### PR DESCRIPTION
- Umstellung des Repos auf gitflow/hubflow branching

Änderungen am Code
- doppeltes menu-div auf der login page weg
- action id für das body tag für besser angepasstes css (damit kann man auf seiten ohne untermenü inhaltsbereich breiter machen
