### PR TITLE
Schließt Ticket #375 - falsche Kodierung in der Schulkonsole bei Benutze...

### DIFF
--- a/lib/Schulkonsole/Config.pm.in
+++ b/lib/Schulkonsole/Config.pm.in
@@ -1031,10 +1031,6 @@ use vars qw(%_id_root_app_names
 
 =over
 
-=item C<$_sophomorix_encoding>
-
-Encoding used to write Sophomorix files
-
 =item C<$_sophomorix_conf_true>
 
 Value used for 'true' in Sophomorix configuration files
@@ -1055,8 +1051,7 @@ Value used for 'false' in backup.conf
 
 =cut
 
-use vars qw($_sophomorix_encoding
-            $_sophomorix_conf_true $_sophomorix_conf_false
+use vars qw($_sophomorix_conf_true $_sophomorix_conf_false
             $_backup_conf_true $_backup_conf_false);
 
 
@@ -1219,8 +1214,6 @@ $_cmd_update_logins = '/usr/share/linuxmuster/scripts/update-logins.sh';
 $_cmd_urlfilter_check = '/usr/share/linuxmuster/scripts/check_urlfilter.sh';
 $_cmd_urlfilter_on_off = '/usr/share/linuxmuster/scripts/urlfilter_on_off.sh';
 
-
-$_sophomorix_encoding = 'iso-8859-15';
 
 $_sophomorix_conf_true = 'yes';
 $_sophomorix_conf_false = 'no';

--- a/src/util/wrapper-sophomorix.pl.in
+++ b/src/util/wrapper-sophomorix.pl.in
@@ -1270,18 +1270,21 @@ $app_id == Schulkonsole::Config::WRITESOPHOMORIXFILEAPP and do {
 
 	my $path;
 	my $filename;
+	my $encoding = "utf8";
 	my @stat;
 	SWITCHWRITEFILE: {
 	$number == 0 and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'lehrer.txt';
 		$stat[2] = 0600;	# set default permissions for this file
+		$encoding = $Conf::encoding_teachers;
 		last SWITCHWRITEFILE;
 	};
 	$number == 1 and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'schueler.txt';
 		$stat[2] = 0600;
+		$encoding = $Conf::encoding_students;
 		last SWITCHWRITEFILE;
 	};
 	$number == 2 and do {
@@ -1306,12 +1309,14 @@ $app_id == Schulkonsole::Config::WRITESOPHOMORIXFILEAPP and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'extraschueler.txt';
 		$stat[2] = 0600;
+		$encoding = $Conf::encoding_students_extra;
 		last SWITCHWRITEFILE;
 	};
 	$number == 6 and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'extrakurse.txt';
 		$stat[2] = 0600;
+		$encoding = $Conf::encoding_courses_extra;
 		last SWITCHWRITEFILE;
 	};
 	}
@@ -1355,7 +1360,7 @@ $app_id == Schulkonsole::Config::WRITESOPHOMORIXFILEAPP and do {
 		$stat[5] = 0;
 	}
 
-	open FILE, ">:encoding($Schulkonsole::Config::_sophomorix_encoding)",
+	open FILE, ">:encoding($encoding)",
 	           $full_filename
 		or exit (  Schulkonsole::Error::Sophomorix::WRAPPER_CANNOT_OPEN_FILE
 		         - Schulkonsole::Error::Sophomorix::WRAPPER_ERROR_BASE);


### PR DESCRIPTION
...rdateien
Die Schulkonsole verwendet jetzt beim Schreiben von Dateien standardmäßig utf8, allerdings für lehrer.txt, schueler.txt, ... die in sophomorix.conf voreingestellten Kodierungen. Ich denke, das sollte in 6.1 noch eingebaut werden, da sich sonst bei Umstellung von sophomrix.conf auf utf8 bei jedem Speichern von schueler.txt eine falsche Kodierung(iso-8859-15) ergibt.
