### PR TITLE
Fix for encoding... not defined in sophomorix.conf (tickets #381,#382)

### DIFF
--- a/src/util/wrapper-sophomorix.pl.in
+++ b/src/util/wrapper-sophomorix.pl.in
@@ -1277,14 +1277,14 @@ $app_id == Schulkonsole::Config::WRITESOPHOMORIXFILEAPP and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'lehrer.txt';
 		$stat[2] = 0600;	# set default permissions for this file
-		$encoding = $Conf::encoding_teachers;
+		$encoding = $Conf::encoding_teachers if defined $Conf::encoding_teachers;
 		last SWITCHWRITEFILE;
 	};
 	$number == 1 and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'schueler.txt';
 		$stat[2] = 0600;
-		$encoding = $Conf::encoding_students;
+		$encoding = $Conf::encoding_students if defined $Conf::encoding_students;
 		last SWITCHWRITEFILE;
 	};
 	$number == 2 and do {
@@ -1309,14 +1309,14 @@ $app_id == Schulkonsole::Config::WRITESOPHOMORIXFILEAPP and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'extraschueler.txt';
 		$stat[2] = 0600;
-		$encoding = $Conf::encoding_students_extra;
+		$encoding = $Conf::encoding_students_extra if defined $Conf::encoding_students_extra;
 		last SWITCHWRITEFILE;
 	};
 	$number == 6 and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'extrakurse.txt';
 		$stat[2] = 0600;
-		$encoding = $Conf::encoding_courses_extra;
+		$encoding = $Conf::encoding_courses_extra if defined $Conf::encoding_courses_extra;
 		last SWITCHWRITEFILE;
 	};
 	}


### PR DESCRIPTION
Ich habe nicht damit gerechnet, das die Variablen in sophomorix.conf nicht unbedingt existieren. Dieser Pull request verhindert, das eine nicht existierende Kodierung verwendet wird. Ist eine encoding...-Variable nicht vorhanden, so wird jetzt stattdessen der default "utf8" verwendet.
