### PR TITLE
verwende encoding Logik von soph-check (fixes #383)

### DIFF
--- a/src/util/wrapper-sophomorix.pl.in
+++ b/src/util/wrapper-sophomorix.pl.in
@@ -1277,14 +1277,22 @@ $app_id == Schulkonsole::Config::WRITESOPHOMORIXFILEAPP and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'lehrer.txt';
 		$stat[2] = 0600;	# set default permissions for this file
-		$encoding = $Conf::encoding_teachers if defined $Conf::encoding_teachers;
+		if (defined $Conf::encoding_teachers) {
+			$encoding = $Conf::encoding_teachers;
+		} elsif (defined $DevelConf::encoding_teachers) {
+			$encoding = $DevelConf::encoding_teachers;
+		}
 		last SWITCHWRITEFILE;
 	};
 	$number == 1 and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'schueler.txt';
 		$stat[2] = 0600;
-		$encoding = $Conf::encoding_students if defined $Conf::encoding_students;
+		if (defined $Conf::encoding_students) {
+			$encoding = $Conf::encoding_students;
+		} elsif (defined $DevelConf::encoding_students) {
+			$encoding = $DevelConf::encoding_students;
+		}
 		last SWITCHWRITEFILE;
 	};
 	$number == 2 and do {
@@ -1309,14 +1317,22 @@ $app_id == Schulkonsole::Config::WRITESOPHOMORIXFILEAPP and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'extraschueler.txt';
 		$stat[2] = 0600;
-		$encoding = $Conf::encoding_students_extra if defined $Conf::encoding_students_extra;
+		if (defined $Conf::encoding_students_extra) {
+			$encoding = $Conf::encoding_students_extra;
+		} elsif (defined $DevelConf::encoding_students_extra) {
+			$encoding = $DevelConf::encoding_students_extra;
+		}
 		last SWITCHWRITEFILE;
 	};
 	$number == 6 and do {
 		$path = $DevelConf::users_pfad;
 		$filename = 'extrakurse.txt';
 		$stat[2] = 0600;
-		$encoding = $Conf::encoding_courses_extra if defined $Conf::encoding_courses_extra;
+		if (defined $Conf::encoding_courses_extra) {
+			$encoding = $Conf::encoding_courses_extra;
+		} elsif (defined $DevelConf::encoding_courses_extra) {
+			$encoding = $DevelConf::encoding_courses_extra;
+		}
 		last SWITCHWRITEFILE;
 	};
 	}


### PR DESCRIPTION
Bitte in linuxmuster-schulkonsole einfügen, der Rückgriff auf sophomorix-devel.conf hatte noch in der Schulkonsole gefehlt. Jetzt sollten keine Kodierungsdifferenzen zwischen sophomorix und der Schulkonsole mehr auftreten.
