### PR TITLE
Fix for #403, needs modification of linuxmuster-pk.

### DIFF
--- a/lib/Schulkonsole/Printer.pm
+++ b/lib/Schulkonsole/Printer.pm
@@ -355,10 +355,10 @@ The password of the user invoking the command
 =head3 Description
 
 This wraps the commands 
-C</usr/bin/linuxmuster-pk --user user -t> 
+C</usr/bin/linuxmuster-pk --user=user -t> 
 to get the number of printed pages 
 and
-C</usr/bin/linuxmuster-pk --user user -m>
+C</usr/bin/linuxmuster-pk --user=user -m>
 maximum number of pages
 with C<user> = the UID of the user with ID C<$id>.
 
@@ -423,10 +423,10 @@ List of UIDs to get quota from
 =head3 Description
 
 This wraps the commands 
-C</usr/bin/linuxmuster-pk --user user -t> 
+C</usr/bin/linuxmuster-pk --user=user -t> 
 to get the number of printed pages 
 and
-C</usr/bin/linuxmuster-pk --user user -m>
+C</usr/bin/linuxmuster-pk --user=user -m>
 maximum number of pages
 invoked for each UID from C<@users> as C<user> 
 

--- a/src/util/wrapper-printer.pl.in
+++ b/src/util/wrapper-printer.pl.in
@@ -275,7 +275,7 @@ None
 =cut
 
 $app_id == Schulkonsole::Config::PRINTERGETOWNQUOTAAPP and do {
-	my $opt_user = "--user \Q$$userdata{uid}\E";
+	my $opt_user = "--user=\Q$$userdata{uid}\E";
 
 
 	my $pages_cmd = Schulkonsole::Encode::to_cli(
@@ -349,7 +349,7 @@ $app_id == Schulkonsole::Config::PRINTERGETQUOTAAPP and do {
 	my $max_cmd = Schulkonsole::Encode::to_cli(
 	                	"$Schulkonsole::Config::_cmd_linuxmuster_pk -m ");
 	foreach my $user (@users) {
-		my $opt_user = Schulkonsole::Encode::to_cli("--user \Q$$userdata{uid}");
+		my $opt_user = Schulkonsole::Encode::to_cli("--user=\Q$$userdata{uid}");
 
 
 		my $pages = `$pages_cmd $opt_user ` or last SWITCH;


### PR DESCRIPTION
This fixes the error message in schulkonsole using start. It needs modification of linuxmuster-pk (patch is attached to #403).
I think this should be committed before releasing 6.1.
